### PR TITLE
Prevent extra BoneHook loss during vanilla BoneBait crafting

### DIFF
--- a/LeatherCrafting/scripts/4_World/craftbonebait.c
+++ b/LeatherCrafting/scripts/4_World/craftbonebait.c
@@ -1,0 +1,12 @@
+modded class CraftBoneBait
+{
+    override bool CanDo(ItemBase ingredients[], PlayerBase player)
+    {
+        if (!super.CanDo(ingredients, player))
+        {
+            return false;
+        }
+
+        return ingredients[1].GetQuantity() == 1;
+    }
+};


### PR DESCRIPTION
For your consideration, this PR attempts to fix a bug causing the player to lose some of their `BoneHook`s when crafting a `BoneBait` using a stack of more than one `BoneHook`.

A more thorough solution to the issue might be to allow the crafting to occur, but cause the extra `BoneHook`s to drop to the ground, instead of letting them disappear completely. This would require considerable more scripting, so I opted to go with the simpler solution.